### PR TITLE
Adds "how to use a headless CMS to Nuxt" to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 - [Handling server side rendering and SEO with nuxt.js](https://medium.com/@devlob/handling-server-side-rendering-and-seo-with-nuxt-js-fa8a2b0ae2ee)
 - [Create a static site in 15 minutes or less using Vue/Nuxt and Netlify](https://codeburst.io/create-a-static-site-in-15-minutes-or-less-using-vue-js-e4e2a9945ee6)
 - [A complete tutorial of Nuxt.js in Spanish 🇪🇸](https://github.com/i62navpm/Tutorial-Nuxt)
+- [How to use a headless CMS with Nuxt](https://www.storyblok.com/tp/headless-cms-nuxtjs)
 
 ### Starter Template
 


### PR DESCRIPTION
We've written a tutorial about how to use a headless CMS like @storyblok with Nuxt.

- Tutorial: https://www.storyblok.com/tp/headless-cms-nuxtjs (added in this PR)
- Source: https://github.com/storyblok/nuxtjs (included in the Tutorial)