### PR TITLE
Add express-template-hot to starter template list

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@
 - [nuxt-community/module-template](https://github.com/nuxt-community/module-template) - Starter template for Nuxt.js Modules
 - [nuxt-community/nuxtent-template](https://github.com/nuxt-community/nuxtent-template) - Starter template for content heavy sites
 - [cretueusebiu/laravel-nuxt](https://github.com/cretueusebiu/laravel-nuxt) - Nuxt.js + Laravel starter template with examples
+- [nekdolan/express-hot](https://github.com/nekdolan/express-template-hot) - Starter template based on express-template using hot reload
 
 ### Docker
 


### PR DESCRIPTION
Express template hot is a copy of express template which separates nuxt and the api server in development mode, but connects the two using a proxy attached to the nuxt server. This prevents file changes from breaking hot reloading of nuxt and the api server reloads faster via live reload as well because it does not need to compile nuxt. You may read more in the backpack readme about the issue.