### PR TITLE
Fix nuxt-vuex-router-sync repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [kenticocloud-nuxt-module](https://github.com/Domitnator/kenticocloud-nuxt-module) - Add Kentico Cloud super power to your nuxt app.
 - [nuxt-client-init-module](https://github.com/potato4d/nuxt-client-init-module) - Provide client version of nuxtServerInit.
 - [Nuxt Webpack Dashboard](https://github.com/paulgv/nuxt-webpackdashboard) - Webpack Dashboard integration for Nuxt.
-- [Nuxt Vuex Router Sync](nuxt-vuex-router-sync) - [vuex-router-sync](https://github.com/vuejs/vuex-router-sync) integration for Nuxt.
+- [Nuxt Vuex Router Sync](https://github.com/paulgv/nuxt-vuex-router-sync) - [vuex-router-sync](https://github.com/vuejs/vuex-router-sync) integration for Nuxt.
 
 ### Tools
 


### PR DESCRIPTION
Made a small mistake in the previous PR to add nuxt-vuex-router-sync to modules list, sorry about that.