### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [Guillermo Rauch - Static and Dynamic Next.js | JSHeroes 2017](https://youtu.be/lLNJsuXB4CI?t=36m50s)
 
 ### Showcase
-- [readable.report](https://readable.report/) - View all of your stats from all of your app with a single easy-to-read report.
+- [readable.report](https://readable.report/) - View all of your stats from all of your apps with a single easy-to-read report.
 - [homefinder.com](https://homefinder.com) - Nation-wide real estate portal in the US.  Find or or sell your home on HomeFinder!
 - [www.gamevix.com](https://www.gamevix.com/) - GameVix: Swap Video Game Discs - Spend much LESS 💰, play much MOAR 🎮! (Nuxt.js + Vuetify.js).
 - [netsells.co.uk](https://netsells.co.uk/) - Web agency website based on Nuxt.js powered by a Laravel backend.


### PR DESCRIPTION
Fixed a typo in our apps description.  Changed `app` to `apps`.