### PR TITLE
Add ghost-nuxt-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-vue-multiselect](https://github.com/spektrummedia/nuxt-vue-multiselect) - Single / multiple select plugin for Nuxt.js using vue-multiselect.
 - [nuxt-optimized-images](https://github.com/bazzite/nuxt-optimized-images) - Automatically optimizes images used in Nuxt.js projects (JPEG, PNG, SVG, WebP and GIF).
 - [nuxt-netlify](https://github.com/bazzite/nuxt-netlify) - Dynamically generate `_headers` and `_redirects` files for Netlify in your Nuxt.js projects.
+- [nuxt-ghost-starter](https://github.com/Maxbrain0/nuxt-ghost-starter) - Generate a static blog using Ghost's Content API
 
 
 ### Tools

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-vue-multiselect](https://github.com/spektrummedia/nuxt-vue-multiselect) - Single / multiple select plugin for Nuxt.js using vue-multiselect.
 - [nuxt-optimized-images](https://github.com/bazzite/nuxt-optimized-images) - Automatically optimizes images used in Nuxt.js projects (JPEG, PNG, SVG, WebP and GIF).
 - [nuxt-netlify](https://github.com/bazzite/nuxt-netlify) - Dynamically generate `_headers` and `_redirects` files for Netlify in your Nuxt.js projects.
-- [nuxt-ghost-starter](https://github.com/Maxbrain0/nuxt-ghost-starter) - Generate a static blog using Ghost's Content API
+- [nuxt-ghost-starter](https://github.com/Maxbrain0/nuxt-ghost-starter) - Generate a static blog using Ghost's Content API.
 
 
 ### Tools


### PR DESCRIPTION
I created a starter for integrating data from the Ghost blogging platform using Ghost's updated Content API for using Ghost as a headless CMS. The data can be used with the nuxt generate command to create a fully static blog for deployment on netlify.

I found this helpful as there was a lot of content on using Ghost with Gatsby, but not with nuxt.

If you think this fits better under blog or otherwise (not at all), let me know!