### PR TITLE
add create-nuxt-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-generate-cluster](https://github.com/nuxt-community/nuxt-generate-cluster) - Multi-threaded generator command for Nuxt.js.
 - [acidjazz/aeonian](https://github.com/acidjazz/aeonian) - Automate the deployment of your Nuxt.js project on AWS S3 + CloudFront.
 - [nuxt-memwatch](https://github.com/pimlie/nuxt-memwatch) - Quickly watch real-time memory stats of your Nuxt app.
+- [create-nuxt-app](https://github.com/nuxt/create-nuxt-app) - Official scaffolding tool for Nuxt.js projects. Create a Nuxt.js project in seconds.
 
 ### Mention of Nuxt.js
 


### PR DESCRIPTION
The official scaffolding tool for Nuxt.js projects is missing.
- https://github.com/nuxt/create-nuxt-app