### PR TITLE
Nuxt socket.io-client module

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-mobile-detect](https://github.com/ChanningDefoe/nuxt-mobile-detect) - Nuxt module for detecting the users device client-side and server-side.
 - [nuxt-bugsnag](https://github.com/JulianMar/nuxt-bugsnag) - Use bugsnag as module.
 - [nuxt-vue-select](https://github.com/madmod/nuxt-vue-select) - Nuxt module for [vue-select](https://vue-select.org/).
+- [nuxt-socket-io](https://github.com/richardeschloss/nuxt-socket-io) - Nuxt module for [socket.io-client](https://github.com/socketio/socket.io-client)! Easy! Works with Nuxt 2.x.
 
 ### Tools
 


### PR DESCRIPTION
Added a link to the nuxt-socket-io module I created, loosely based off the example in the official nuxt repo. There are key differences now this module offers compared to the example:

1. This module is now just something you `npm install`. 
2. Instead of setting env vars, set the module options. The module expects to receive an array of sockets that the app can easily use. The module's README.md file will contain the latest info and description of benefits.
3. This is the module you always wanted but didn't know you wanted. If you think axios is cool, you might love this even more. 