### PR TITLE
Added nuxt-apis-to-file to Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-basic-auth-module](https://github.com/potato4d/nuxt-basic-auth-module) - Provide basic auth your Nuxt.js application.
 - [nuxt-wizard](https://www.npmjs.com/package/nuxt-wizard) - Command-line interface for scaffolding Nuxt projects.
 - [nuxt-payload-extractor](https://github.com/DreaMinder/nuxt-payload-extractor) - Module that saves external API data to static JSON files on 'nuxt generate' command, making your project fully static.
+- [nuxt-apis-to-file](https://github.com/LuXDAmore/nuxt-apis-to-file) - Module to merge and transform static API calls into a single file during the build process.
 - [cloudcms-nuxt](https://github.com/gitana/cloudcms-nuxt) - Cloud CMS Nuxt integration.
 - [nuxt-vue-multiselect](https://github.com/spektrummedia/nuxt-vue-multiselect) - Single / multiple select plugin for Nuxt.js using vue-multiselect.
 - [nuxt-optimized-images](https://github.com/bazzite/nuxt-optimized-images) - Automatically optimizes images used in Nuxt.js projects (JPEG, PNG, SVG, WebP and GIF).


### PR DESCRIPTION
I've made this module because i can't `generate` my website and i was calling 4 different types of `static API` in my `nuxtServerInit action`. These calls are slowing down my website because the server need time to response to every request.

Now i can pre-generate all of these requests during the build-process and i have only 1 request (made by webpack) in the nuxtServerInit.

In this way, i'm also protecting my data because i don't have to expose the `data.json` file in the `static/` dir.