### PR TITLE
Add 'Community Examples' heading, with nuxt-cypress-example repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [Starter Template](#starter-template)
 - [Docker](#docker)
 - [Official Examples](#official-examples)
+- [Community Examples](#community-examples)
 - [Projects Using Nuxt.js](#projects-using-nuxtjs)
 
 ### Official Resources

--- a/README.md
+++ b/README.md
@@ -418,6 +418,10 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [Internationalization (i18n)](https://nuxtjs.org/examples/i18n) - Nuxt.js app with i18n support and implementation.
 - [Hackernews](https://github.com/nuxt/hackernews) - Nuxt.js Hackernews clone.
 
+### Community Examples
+
+- [hex-digital/nuxt-cypress-example](https://github.com/hex-digital/nuxt-cypress-example) - Examples of Cypress tests on different Nuxt functionality, including Nuxt auth and more.
+
 ### Projects Using Nuxt.js
 
 - [Amujamu](https://amujamu.com) - Amujamu has the largest collection of Thailand tours. Book your desired one for the best deal. Amujamu, the best of its kind, should be your first choice when it comes to booking tours for Thailand. Tourism Authority of Thailand (TAT) approved tours &amp; activity marketplace.


### PR DESCRIPTION
While searching around for examples of Cypress testing Nuxt functionality, I couldn't find much content or many examples for Nuxt. The only example on awesome-nuxt was a starter kit with Cypress pre-installed, but the one example it included was very basic DOM testing.

The https://github.com/hex-digital/nuxt-cypress-example repo is a showcase of examples of Cypress testing your features within a Nuxt application. It currently shows visiting pages, DOM testing, submitting a form and testing the store, including login with Nuxt auth.

-=-

While looking for a place to add this repo, we were unsure what category to place it under. While it could be used as a Starter Kit, that's not really its intention. It's not a website to showcase, so I wasn't sure about putting it under that category either. 

In the end, I've added a **Community Examples** title, underneath the Official Examples. If this needs to change, please let me know and I'll resolve. If you agree with the title, but would prefer it to be done in its own PR, I can happily do that as well.