### PR TITLE
Add nuxt-intercom to list of community modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-prune-html](https://github.com/LuXDAmore/nuxt-prune-html) - Module to prune html before sending it to the browser (it removes elements matching CSS selector(s)), useful for boosting performance showing a different HTML for bots.
 - [nuxt-page-generator-helper](https://github.com/GrabarzUndPartner/nuxt-page-generator-helper) - Generate your pages statically without using payload extractors.
 - [nuxt-font-loader-strategy](https://github.com/GrabarzUndPartner/nuxt-font-loader-strategy) - Helps to load fonts and activate them by preloading.
+- [hex-digital/nuxt-intercom](https://github.com/hex-digital/nuxt-intercom) - Nuxt module for simple integration with [Intercom](https://www.intercom.com/).
 
 ### Tools
 


### PR DESCRIPTION
This PR adds https://github.com/hex-digital/nuxt-intercom to the list of Community Modules.

This module allows the simple addition of Intercom, a common live-chat application. It augments it with functionality that allows it to work inside an SPA or Universal app.