### PR TITLE
Added nuxt-canvas-sketch to Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-font-loader-strategy](https://github.com/GrabarzUndPartner/nuxt-font-loader-strategy) - Helps to load fonts and activate them by preloading.
 - [hex-digital/nuxt-intercom](https://github.com/hex-digital/nuxt-intercom) - Nuxt module for simple integration with [Intercom](https://www.intercom.com/).
 - [nuxt-micro-frontend](https://github.com/FEMessage/nuxt-micro-frontend) - make Nuxt app as sub application with [qiankun](https://qiankun.umijs.org/) or [single-SPA](https://single-spa.js.org/).
+-[nuxt-canvas-sketch](https://github.com/LuXDAmore/generative-art) - A porting of [canvas-sketch](https://github.com/mattdesl/canvas-sketch) to make generative art (or threejs art) with nuxt.
 
 ### Tools
 


### PR DESCRIPTION
Module to inject [canvas-sketch](https://github.com/mattdesl/canvas-sketch) draw methods.
These library was born for the purpose of making generative art (or threejs art) with nuxt.