### PR TITLE
Add nuxt-gmaps module

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-highcharts](https://github.com/richardeschloss/nuxt-highcharts) - Highcharts for Nuxt. Similar to highcharts-vue, but adapted for Nuxt with some added benefits.
 - [nuxt-test-utils](https://github.com/richardeschloss/nuxt-test-utils) - All your favorite test utils in one repo, and some extras.
 - [nuxt-scss-to-js](https://github.com/sugoidesune/nuxt-scss-to-js) - Use SCSS variables inside your Components/Templates/Scripts.
-
+- [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
 
 ### Tools
 


### PR DESCRIPTION
Added a link to the [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) module, which I use since a while.