### PR TITLE
docs: add @nuxtjs/storybook to community modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-test-utils](https://github.com/richardeschloss/nuxt-test-utils) - All your favorite test utils in one repo, and some extras.
 - [nuxt-scss-to-js](https://github.com/sugoidesune/nuxt-scss-to-js) - Use SCSS variables inside your Components/Templates/Scripts.
 - [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
+- [storybook](https://github.com/nuxt-community/storybook) - Storybook integration with NuxtJS
 
 ### Tools
 


### PR DESCRIPTION
Hi! I recommend a [`@nuxtjs/stroybook`](https://github.com/nuxt-community/storybook) that makes it really **easy** 😋 to integrate the [`storybook`](https://storybook.js.org/) into nuxt.