### PR TITLE
Add nuxt-highlightjs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [nuxt-test-utils](https://github.com/richardeschloss/nuxt-test-utils) - All your favorite test utils in one repo, and some extras.
 - [nuxt-scss-to-js](https://github.com/sugoidesune/nuxt-scss-to-js) - Use SCSS variables inside your Components/Templates/Scripts.
 - [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
+- [nuxt-highlightjs](https://github.com/Llang8/nuxt-highlightjs) - Highlight.js syntax highlighting for Nuxt JS.
 
 ### Tools
 


### PR DESCRIPTION
Added a link to nuxt-highlightjs module, for code syntax highlighting on nuxt sites.