### PR TITLE
Add create-nuxt-netlify-cms-docs package

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [acidjazz/aeonian](https://github.com/acidjazz/aeonian) - Automate the deployment of your Nuxt.js project on AWS S3 + CloudFront.
 - [nuxt-memwatch](https://github.com/pimlie/nuxt-memwatch) - Quickly watch real-time memory stats of your Nuxt app.
 - [create-nuxt-app](https://github.com/nuxt/create-nuxt-app) - Official scaffolding tool for Nuxt.js projects. Create a Nuxt.js project in seconds.
+- [create-nuxt-netlify-cms-docs](https://github.com/RoboMx/create-nuxt-netlify-cms-docs) - Create Nuxt based docs with Netlify CMS as content manager.
 
 ### Mention of Nuxt.js
 


### PR DESCRIPTION
Create a documentation with @nuxt/netlify-cms-docs

## Features:
* CLI based generation
* Netlify CMS content manager

NPM: https://www.npmjs.com/package/create-nuxt-netlify-cms-docs
Github: https://github.com/RoboMx/create-nuxt-netlify-cms-docs