### PR TITLE
feat: add nuxt-jsonapi community module

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Nuxt.js is a framework for creating Universal Vue.js Applications.
 - [xhr-cache](https://github.com/gaetansenn/xhr-cache) - Cache api resources and serve it as static resource with Nuxt.js.
 - [nuxt-precompress](https://github.com/frenchrabbit/nuxt-precompress) - Nuxt module for compressing gzip and brotli at buildtime and serving supported encoding in runtime.
 - [nuxtjs-ghost](https://github.com/ditschedev/nuxtjs-ghost) - Easy to use wrapper for Ghost's Content API.
+- [nuxt-jsonapi](https://github.com/patrickcate/nuxt-jsonapi) - JSON:API client for Nuxt.js.
 
 ### Tools
 


### PR DESCRIPTION
Add [nuxt-jsonapi](https://github.com/patrickcate/nuxt-jsonapi) community module. Enables easy [JSON:API](https://jsonapi.org) client integration for Nuxt.