### PR TITLE
feat: add vue-notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-scss-to-js](https://github.com/sugoidesune/nuxt-scss-to-js) - Use SCSS variables inside your Components/Templates/Scripts.
 - [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
 - [nuxt-highlightjs](https://github.com/Llang8/nuxt-highlightjs) - Highlight.js syntax highlighting for Nuxt JS.
+- [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
 
 ### Tools
 


### PR DESCRIPTION
Add `vue-notion` to the list, which allows using Notion as a CMS for Nuxt sites.