### PR TITLE
feat: add nuxt-content-algolia module

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
 - [nuxt-highlightjs](https://github.com/Llang8/nuxt-highlightjs) - Highlight.js syntax highlighting for Nuxt JS.
 - [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
+- [nuxt-content-algolia](https://github.com/danielkellyio/nuxt-content-algolia) - Automatically sync content stored in your project with nuxt content to an Algolia index.
 
 ### Tools
 


### PR DESCRIPTION
https://github.com/danielkellyio/nuxt-content-algolia

Automatically (during npm run generate) sync content stored in your project with nuxt content to an Algolia index. This allows you to manage your content in your repo while providing powerful search capabilities to your site users.

Works great with sites hosted on Netlify, etc that automatically run your build command when you commit new content.