### PR TITLE
feat: add nuxt-iconfont-generator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
 - [nuxt-highlightjs](https://github.com/Llang8/nuxt-highlightjs) - Highlight.js syntax highlighting for Nuxt JS.
 - [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
-- [nuxt-iconfont-generator](https://github.com/kdydesign/nuxt-iconfont-generator) - Easy convert SVG from nuxt to icon font.
+- [nuxt-fontagon](https://github.com/kdydesign/nuxt-fontagon) - Easy convert SVG from nuxt to icon font.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-gmaps](https://gitlab.com/broj42/nuxt-gmaps) - Easy integration of Google Maps with many setting options.
 - [nuxt-highlightjs](https://github.com/Llang8/nuxt-highlightjs) - Highlight.js syntax highlighting for Nuxt JS.
 - [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
+- [nuxt-iconfont-generator](https://github.com/kdydesign/nuxt-iconfont-generator) - Easy convert SVG from nuxt to icon font.
 
 ### Tools
 


### PR DESCRIPTION
When Nuxt.js were build, they created a module that could generate SVG as an icon-font file. Font files, css, stylus, less, sass are created and can be easily created and used inside Nuxt.js.
