### PR TITLE
feat: add nuxt-humans-txt community module

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-highlightjs](https://github.com/Llang8/nuxt-highlightjs) - Highlight.js syntax highlighting for Nuxt JS.
 - [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
 - [nuxt-fontagon](https://github.com/kdydesign/nuxt-fontagon) - Easy convert SVG from nuxt to icon font.
+- [nuxt-humans-txt](https://github.com/LuXDAmore/nuxt-humans-txt) - An initiative to know the creators of a website. Contains the information about humans to the web building - A module to statically integrate and generate a `humans.txt` author file - Based on the  [HumansTxt organization project](http://humanstxt.org/).
 
 ### Tools
 


### PR DESCRIPTION
Add nuxt-humans-txt community module. Enables integration of the [HumansTxt organization project](http://humanstxt.org) for Nuxt.