### PR TITLE
feat: add nuxtjs-public-google-sheets-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
 - [nuxt-fontagon](https://github.com/kdydesign/nuxt-fontagon) - Easy convert SVG from nuxt to icon font.
 - [nuxt-humans-txt](https://github.com/LuXDAmore/nuxt-humans-txt) - An initiative to know the creators of a website. Contains the information about humans to the web building - A module to statically integrate and generate a `humans.txt` author file - Based on the  [HumansTxt organization project](http://humanstxt.org/).
+- [nuxtjs-public-google-sheets-parser](https://github.com/fureweb-com/nuxtjs-public-google-sheets-parser) - Easily import data from published Google Sheets.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [vue-notion](https://github.com/janniks/vue-notion) - Use Notion as a CMS for Nuxt JS, as seen in [this example](https://vue-notion.now.sh/basic-example).
 - [nuxt-fontagon](https://github.com/kdydesign/nuxt-fontagon) - Easy convert SVG from nuxt to icon font.
 - [nuxt-humans-txt](https://github.com/LuXDAmore/nuxt-humans-txt) - An initiative to know the creators of a website. Contains the information about humans to the web building - A module to statically integrate and generate a `humans.txt` author file - Based on the  [HumansTxt organization project](http://humanstxt.org/).
-- [nuxtjs-public-google-sheets-parser](https://github.com/fureweb-com/nuxtjs-public-google-sheets-parser) - Easily import data from published Google Sheets.
+- [nuxt-google-sheets-parser](https://github.com/fureweb-com/nuxt-google-sheets-parser) - Easily import data from published Google Sheets.
 
 ### Tools
 


### PR DESCRIPTION
Add nuxtjs-public-google-sheets-parser community module.
Using this, easily import data from published Google Sheets.