### PR TITLE
feat: add Adyen Payment Module for Nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-appwrite](https://github.com/Hrdtr/nuxt-appwrite) - [Appwrite](https://appwrite.io) module for Nuxt.
 - [nuxt-storybook](https://github.com/nuxt-community/storybook) - Storybook integration with NuxtJS.
 - [nuxt-speedkit](https://github.com/GrabarzUndPartner/nuxt-speedkit) - nuxt-speedkit will help you to improve the lighthouse performance score (100/100) of your website. 
-- [nuxt-adyen-module](https://github.com/Baroshem/nuxt-adyen-module) - [Adyen](https://www.adyen.com/) Payment module for Nuxt.js
+- [nuxt-adyen-module](https://github.com/Baroshem/nuxt-adyen-module) 
+- [Adyen](https://www.adyen.com/) Payment module for Nuxt.js
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-appwrite](https://github.com/Hrdtr/nuxt-appwrite) - [Appwrite](https://appwrite.io) module for Nuxt.
 - [nuxt-storybook](https://github.com/nuxt-community/storybook) - Storybook integration with NuxtJS.
 - [nuxt-speedkit](https://github.com/GrabarzUndPartner/nuxt-speedkit) - nuxt-speedkit will help you to improve the lighthouse performance score (100/100) of your website. 
+- [nuxt-adyen-module](https://github.com/Baroshem/nuxt-adyen-module) - [Adyen](https://www.adyen.com/) Payment module for Nuxt.js
 
 ### Tools
 


### PR DESCRIPTION
Currently supporting:
* Easier configuration for Adyen dropin and Checkout in a form of a Nuxt module
* AdyenCheckout.vue component ready to embed in your website
* Simple error handling

Upcoming:
* Full payment support handled on the backend
* More customizability options for AdyenCheckout component.
* Allow Card component customization