### PR TITLE
rename @nuxt-commerce to @nuxt-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [nuxt-adyen-module](https://github.com/Baroshem/nuxt-adyen-module) [Adyen](https://www.adyen.com/) Payment module for Nuxt.js
 - [nuxt-speedkit](https://github.com/GrabarzUndPartner/nuxt-speedkit) - nuxt-speedkit will help you to improve the lighthouse performance score (100/100) of your website.
 - [nuxt-bigcommerce](https://github.com/Baroshem/nuxt-bigcommerce) - Easy BigCommerce integration for Nuxt.js
-- [@nuxt-commerce/algolia](https://github.com/nuxt-commerce/algolia) - Algolia integration for Nuxt 3
+- [@nuxt-modules/algolia](https://github.com/nuxt-modules/algolia) - Algolia integration for Nuxt 3
 
 
 ### Tools


### PR DESCRIPTION
I was asked to change the organization name.