### PR TITLE
feat: add nuxt-block-russia-belarus module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Discover the full list of Nuxt modules on https://modules.nuxtjs.org
 - [@nuxt-commerce/algolia](https://github.com/nuxt-commerce/algolia) - Algolia integration for Nuxt 3
 - [@nuxt-modules/cache](https://github.com/nuxt-modules/cache) - Browser and Server Cache module for Nuxt 3
 - [@nuxt-commerce/nuxt-tailvue](https://github.com/acidjazz/nuxt-tailvue) - Out of the box Tailwind CSS components
+- [nuxt-block-russia-belarus](https://github.com/kevinl95/nuxt-block-russia-belarus) - Nuxt module to soft-block users from Russia and Belarus during the invasion of Ukraine.
 
 
 ### Tools


### PR DESCRIPTION
This module adds a soft-block to websites it is added to that displays a message or redirects users from Russia or Belarus during the invasion of Ukraine.